### PR TITLE
fix(setup): не удалять сущности из реестра, когда первый опрос ZONT не удался

### DIFF
--- a/custom_components/zont_ha/__init__.py
+++ b/custom_components/zont_ha/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.entity_registry import async_get
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator, UpdateFailed
@@ -105,6 +106,15 @@ async def async_setup_entry(
     await zont.init_old_data()
     coordinator = ZontCoordinator(hass, zont)
     await coordinator.async_config_entry_first_refresh()
+    if getattr(zont, 'data', None) is None:
+        # Координатор глотает первые COUNTER_CONNECT отказов и возвращает
+        # объект без данных, поэтому first_refresh проходит даже когда API
+        # ZONT не ответил. Дальше платформы падают на zont.data.devices, а
+        # чистка реестра сносит все сущности аккаунта. Отдаём HA штатный
+        # ConfigEntryNotReady: он повторит настройку сам.
+        raise ConfigEntryNotReady(
+            'ZONT не отдал данные при первом опросе, откладываем настройку'
+        )
     _LOGGER.debug(f'config entry data: {config_entry.data}')
 
     register_webhook(hass, entry_id, email, selected_devices)
@@ -119,7 +129,15 @@ async def async_setup_entry(
         config_entry, PLATFORMS
     )
     current_entries_id = hass.data[DOMAIN][CURRENT_ENTITY_IDS][entry_id]
-    remove_entity(hass, current_entries_id, config_entry)
+    if current_entries_id:
+        remove_entity(hass, current_entries_id, config_entry)
+    else:
+        # Пустой список значит, что ни одна платформа не поднялась.
+        # Это отказ опроса, а не исчезновение устройств: чистить реестр
+        # в этом случае нельзя, иначе теряются все сущности аккаунта.
+        _LOGGER.warning(
+            'Список актуальных сущностей пуст, очистка реестра пропущена'
+        )
     _LOGGER.debug(f'The unique ID of the current account entities {zont.mail}:'
                   f' {current_entries_id}')
     _LOGGER.debug(f'Number of relevant entities: '


### PR DESCRIPTION
## Проблема

Если первый опрос API ZONT при старте Home Assistant не удался, интеграция удаляет из реестра **все** сущности аккаунта.

01.09.2026 это случилось на живой системе: после обычного рестарта HA из реестра пропали все 17 сущностей котла — оба климата, кнопки режимов, бинарные сенсоры, датчики и device_tracker. Для пользователя котёл просто исчез из Home Assistant.

## Механизм

`ZontCoordinator._async_update_data()` намеренно терпит первые `COUNTER_CONNECT` отказов и возвращает `self.zont` без данных:

```python
except Exception as err:
    if self._count_connect < COUNTER_CONNECT:
        self._count_connect += 1
        _LOGGER.warning(err)
        _LOGGER.warning(f'Неудачная попытка обновления данных ZONT. ...')
        return self.zont
```

Для периодических опросов это правильно, но `async_config_entry_first_refresh()` из-за этого **завершается успешно даже когда API не ответил**, и `async_setup_entry` продолжает работу с `zont.data is None`. Дальше по цепочке:

1. все платформы падают на `zont.data.devices`:
   `AttributeError: 'NoneType' object has no attribute 'devices'`;
2. поэтому ни одна не наполняет `hass.data[DOMAIN][CURRENT_ENTITY_IDS][entry_id]` — список остаётся пустым;
3. `remove_entity(hass, current_entries_id, config_entry)` считает устаревшей **каждую** сущность этого config entry и удаляет её из реестра.

Из лога инцидента:

```
Неудачная попытка обновления данных ZONT. Осталось попыток: 9
Error while setting up zont_ha platform for climate: 'NoneType' object has no attribute 'devices'
... (то же для sensor, binary_sensor, switch, button, alarm_control_panel, device_tracker)
Number of relevant entities: 0
The unique ID of the current account entities <email>: []
Outdated entity deleted climate.kotel_kotel_otoplenie
Outdated entity deleted climate.kotel_kotel_gvs
Outdated entity deleted button.kotel_kotel_komfort
... всего 17 строк
```

Само по себе это не чинится: config entry остаётся в состоянии `loaded`, повторные опросы проходят успешно, но сущностей уже нет. Помогает только ручная перезагрузка config entry, о которой пользователь не догадывается.

## Что меняет PR

Две независимые защиты, обе в `async_setup_entry`, `custom_components/zont_ha/__init__.py`:

1. **`ConfigEntryNotReady`, если после первого опроса `zont.data` пуст.** Home Assistant сам повторит настройку позже — это штатный механизм для «интеграция ещё не готова». Лучше отложенная настройка, чем поднятая наполовину.
2. **Очистка реестра не выполняется при пустом списке актуальных сущностей.** Пустой список означает «ни одна платформа не поднялась», а не «все устройства исчезли из аккаунта». Реальное исчезновение устройства даёт непустой список без этого устройства — этот сценарий работает как раньше.

Толерантность координатора к отказам при периодических опросах намеренно не тронута — меняется только поведение при старте.

## Объём

Один файл, `+19 −1`. В нормальном сценарии поведение не меняется: `zont.data` заполнен, список актуальных сущностей непустой, очистка реестра идёт как прежде.

## Проверка

- **Воспроизведение** — инцидент выше, на боевой системе с ZONT H-1: отказ первого опроса при рестарте HA, 17 удалённых записей реестра, восстановление ручной перезагрузкой config entry.
- **Патч задеплоен на ту же систему и отработал рестарт HA.** Нормальный сценарий не изменился: `Number of relevant entities: 16`, очистка реестра прошла как прежде, ни одной ошибки платформ, `ConfigEntryNotReady` не поднимался — API ответил.
- Ветку отказа живьём не воспроизводил: она требует недоступного API ровно в момент старта. Обе защиты — проверки на пустое значение перед уже существующим кодом, поведение при заполненных данных побитово прежнее.
