### PR TITLE
fix(const): убрать из ZONT_API_URLS дубль и неотвечающий адрес

### DIFF
--- a/custom_components/zont_ha/const.py
+++ b/custom_components/zont_ha/const.py
@@ -13,8 +13,6 @@ CURRENT_ENTITY_IDS = 'current_entity_ids'
 ZONT_API_URLS = [
     'https://my.zont.online/',
     'https://lk.zont-online.ru/',
-    'https://lk.zont-online.ru/',
-    'https://zont-online.com',
 ]
 
 ZONT_API_URL_ROOT = 'api/'


### PR DESCRIPTION
## Что не так

В `ZONT_API_URLS` четыре элемента, из которых полезны два:

```python
ZONT_API_URLS = [
    'https://my.zont.online/',
    'https://lk.zont-online.ru/',
    'https://lk.zont-online.ru/',   # дубль предыдущего
    'https://zont-online.com',      # не отвечает
]
```

Замер с рабочего сервера (POST на `<base>api/widget/v3/devices`, таймаут 12 с):

| адрес | код |
|---|---|
| `https://my.zont.online/` | 403 |
| `https://lk.zont-online.ru/` | 403 |
| `https://zont-online.com` | нет ответа (000) |

403 здесь ожидаем — запрос без токена, важно что хост отвечает. Третий адрес не отвечает вообще.

## Почему это заметно

Список — цепочка фолбэков. Дубль означает, что при недоступности `lk.zont-online.ru` он будет опрошен дважды подряд, а мёртвый `zont-online.com` добавляет ещё один таймаут в хвост. Каждая лишняя попытка — это время внутри `TIME_OUT_UPDATE_DATA`, после которого опрос считается неудачным.

Отдельно замечу: у `zont-online.com` ещё и нет завершающего слэша, в отличие от остальных, — при склейке с `ZONT_API_URL_ROOT = 'api/'` получился бы `zont-online.comapi/`.

## Что меняет PR

Убраны две строки — дубль и неотвечающий адрес. Больше ничего.
